### PR TITLE
Update version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Include the Homoglyph library in your project by downloading it from Maven Centr
 <dependency>
     <groupId>net.codebox</groupId>
     <artifactId>homoglyph</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Heya,

I was testing out this library and noticed that the library version in `README.md` is slightly [outdated](https://mvnrepository.com/artifact/net.codebox/homoglyph/1.2.1). This PR should fix it.